### PR TITLE
feat: add URL query parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (e.g. `Api-Key`) and same-origin cookies are unaffected.
 
 ### Added
+- `StandardApi.Url.Parser.Query` module for parsing URL query strings back into
+  `Query` values, complementing the existing URL builder. Supports type-driven
+  decoding, strict error handling, and roundtrip conversion.
+- `StandardApi.Type` module exposing type information for schema fields.
+- `modelToTypes` helper function to convert schema `Model` to type mappings for
+  the parser.
 - `Neq` operator for not-equal comparisons in predicates. Serializes to
   `not_eq` query parameter, following StandardAPI conventions.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,42 @@ SaUrl.absolute [ "accounts" ]
 --> "/accounts?include%5Bemails%5D=true"
 ```
 
+# URL Parser
+
+Parse URL query strings back into `Query` values using
+`StandardApi.Url.Parser.Query`:
+
+```elm
+import StandardApi exposing (..)
+import StandardApi.Type as Type
+import StandardApi.Url.Parser.Query as Parser
+
+-- Without type info, values are guessed from the raw string
+Parser.parse [] "limit=10&order%5Bcreated_at%5D=desc"
+--> Ok { emptyQuery | limit = Just 10, order = [ ( "created_at", Desc ) ] }
+
+-- With type info, values are decoded according to the schema
+Parser.parse [ ( "id", Type.Int ) ] "where%5Bid%5D%5Beq%5D=42"
+--> Ok { emptyQuery | predicate = Just (Eq [ "id" ] (Int 42)) }
+
+-- Type mismatches produce clear error messages
+Parser.parse [ ( "id", Type.Int ) ] "where%5Bid%5D%5Beq%5D=abc"
+--> Err "expected integer for id, got: abc"
+```
+
+If you have a `Model` from the schema, convert it to type mappings with
+`modelToTypes`:
+
+```elm
+Parser.parse (modelToTypes model) queryString
+```
+
+You can also parse directly from a `Url`:
+
+```elm
+Parser.parseUrl [] url
+```
+
 # Example
 
 ```elm

--- a/elm.json
+++ b/elm.json
@@ -6,7 +6,9 @@
     "version": "7.1.3",
     "exposed-modules": [
         "StandardApi",
-        "StandardApi.Url.Builder"
+        "StandardApi.Type",
+        "StandardApi.Url.Builder",
+        "StandardApi.Url.Parser.Query"
     ],
     "elm-version": "0.19.1 <= v <= 0.20.0",
     "dependencies": {

--- a/src/StandardApi.elm
+++ b/src/StandardApi.elm
@@ -8,6 +8,7 @@ module StandardApi exposing
     , expectJson, expectWhatever, jsonResolver
     , Query, Operation(..), Direction(..), Limit, Offset, Order, Value(..), Include(..)
     , emptyQuery, include, unwrapInclude
+    , modelToTypes
     )
 
 {-| Module for interfacing with StandardAPI.
@@ -49,7 +50,7 @@ For example you can make queries like the following:
 # Querying
 
 @docs Query, Operation, Direction, Limit, Offset, Order, Value, Include
-@docs emptyQuery, include, unwrapInclude
+@docs emptyQuery, include, unwrapInclude, modelToTypes
 
 
 # Url generation
@@ -66,6 +67,7 @@ import Json.Decode.Extra as Decode exposing (..)
 import Json.Decode.Pipeline exposing (hardcoded, required)
 import Json.Encode as Encode
 import Json.Encode.Extra as Encode
+import StandardApi.Type as Type exposing (Type)
 import Task exposing (Task)
 import Time exposing (Posix)
 import Tree exposing (Tree, tree)
@@ -282,6 +284,18 @@ emptyQuery =
     }
 
 
+{-| Convert a `Model` to a list of `( String, Type )` pairs suitable for
+passing to `StandardApi.Url.Parser.Query.parse`.
+
+    modelToTypes { name = "test", attributes = [ { name = "id", type_ = Type.Int, default = Nothing, primaryKey = True, null = False, array = False, comment = "" } ], comment = "" }
+    --> [ ( "id", Type.Int ) ]
+
+-}
+modelToTypes : Model -> List ( String, Type.Type )
+modelToTypes model =
+    List.map (\attr -> ( attr.name, attr.type_ )) model.attributes
+
+
 {-| Create a HTTP request to a StandardAPI enpoint.
 
     import Url exposing (Protocol(..))
@@ -424,7 +438,7 @@ type alias Model =
 -}
 type alias Attribute =
     { name : String
-    , type_ : String
+    , type_ : Type
     , default : Maybe String
     , primaryKey : Bool
     , null : Bool
@@ -557,7 +571,18 @@ attributeDecoder : Decoder Attribute
 attributeDecoder =
     Decode.succeed Attribute
         |> hardcoded ""
-        |> required "type" string
+        |> required "type"
+            (string
+                |> Decode.andThen
+                    (\s ->
+                        case Type.fromString s of
+                            Ok t ->
+                                Decode.succeed t
+
+                            Err err ->
+                                Decode.fail err
+                    )
+            )
         |> required "default" (maybe string)
         |> required "primary_key" bool
         |> required "null" bool

--- a/src/StandardApi.elm
+++ b/src/StandardApi.elm
@@ -7,8 +7,7 @@ module StandardApi exposing
     , emptyBody, jsonBody
     , expectJson, expectWhatever, jsonResolver
     , Query, Operation(..), Direction(..), Limit, Offset, Order, Value(..), Include(..)
-    , emptyQuery, include, unwrapInclude
-    , modelToTypes
+    , emptyQuery, include, unwrapInclude, modelToTypes
     )
 
 {-| Module for interfacing with StandardAPI.
@@ -286,6 +285,8 @@ emptyQuery =
 
 {-| Convert a `Model` to a list of `( String, Type )` pairs suitable for
 passing to `StandardApi.Url.Parser.Query.parse`.
+
+    import StandardApi.Type as Type
 
     modelToTypes { name = "test", attributes = [ { name = "id", type_ = Type.Int, default = Nothing, primaryKey = True, null = False, array = False, comment = "" } ], comment = "" }
     --> [ ( "id", Type.Int ) ]

--- a/src/StandardApi.elm
+++ b/src/StandardApi.elm
@@ -184,6 +184,7 @@ type Value
     | Bool Bool
     | Posix Posix
     | Dict (Dict String Value)
+    | Decimal String
 
 
 {-| The `Operation` type is used for making comparisons in a predicate.

--- a/src/StandardApi/Type.elm
+++ b/src/StandardApi/Type.elm
@@ -18,9 +18,12 @@ type Type
     | Bool
     | Posix
     | Dict
+    | Decimal
 
 
-{-| Parse a type string from the server into a `Type`.
+{-| Parse a type string from the server into a `Type`. Unrecognized types
+default to `String` so that the attribute decoder never fails on unknown
+PostgreSQL or Rails types.
 
     fromString "integer"
     --> Ok Int
@@ -32,13 +35,31 @@ type Type
     --> Ok Posix
 
     fromString "decimal"
-    --> Ok Float
+    --> Ok Decimal
 
     fromString "boolean"
     --> Ok Bool
 
     fromString "hash"
     --> Ok Dict
+
+    fromString "text"
+    --> Ok String
+
+    fromString "uuid"
+    --> Ok String
+
+    fromString "jsonb"
+    --> Ok Dict
+
+    fromString "numeric"
+    --> Ok Float
+
+    fromString "date"
+    --> Ok String
+
+    fromString "inet"
+    --> Ok String
 
 -}
 fromString : String -> Result String Type
@@ -47,10 +68,52 @@ fromString str =
         "integer" ->
             Ok Int
 
+        "bigint" ->
+            Ok Int
+
+        "smallint" ->
+            Ok Int
+
         "string" ->
             Ok String
 
+        "text" ->
+            Ok String
+
+        "uuid" ->
+            Ok String
+
+        "inet" ->
+            Ok String
+
+        "cidr" ->
+            Ok String
+
+        "macaddr" ->
+            Ok String
+
+        "citext" ->
+            Ok String
+
+        "binary" ->
+            Ok String
+
+        "date" ->
+            Ok String
+
+        "time" ->
+            Ok String
+
         "decimal" ->
+            Ok Decimal
+
+        "numeric" ->
+            Ok Decimal
+
+        "money" ->
+            Ok Decimal
+
+        "float" ->
             Ok Float
 
         "boolean" ->
@@ -62,5 +125,14 @@ fromString str =
         "hash" ->
             Ok Dict
 
+        "hstore" ->
+            Ok Dict
+
+        "json" ->
+            Ok Dict
+
+        "jsonb" ->
+            Ok Dict
+
         _ ->
-            Err ("unknown type: " ++ str)
+            Ok String

--- a/src/StandardApi/Type.elm
+++ b/src/StandardApi/Type.elm
@@ -1,0 +1,66 @@
+module StandardApi.Type exposing (Type(..), fromString)
+
+{-| Types for StandardAPI attributes.
+
+@docs Type, fromString
+
+-}
+
+
+{-| The type of a StandardAPI attribute. This mirrors the value types in
+`StandardApi.Value` and is used by the schema decoder and URL query parser
+to determine how to interpret raw string values.
+-}
+type Type
+    = Int
+    | String
+    | Float
+    | Bool
+    | Posix
+    | Dict
+
+
+{-| Parse a type string from the server into a `Type`.
+
+    fromString "integer"
+    --> Ok Int
+
+    fromString "string"
+    --> Ok String
+
+    fromString "datetime"
+    --> Ok Posix
+
+    fromString "decimal"
+    --> Ok Float
+
+    fromString "boolean"
+    --> Ok Bool
+
+    fromString "hash"
+    --> Ok Dict
+
+-}
+fromString : String -> Result String Type
+fromString str =
+    case str of
+        "integer" ->
+            Ok Int
+
+        "string" ->
+            Ok String
+
+        "decimal" ->
+            Ok Float
+
+        "boolean" ->
+            Ok Bool
+
+        "datetime" ->
+            Ok Posix
+
+        "hash" ->
+            Ok Dict
+
+        _ ->
+            Err ("unknown type: " ++ str)

--- a/src/StandardApi/Url/Builder.elm
+++ b/src/StandardApi/Url/Builder.elm
@@ -327,6 +327,9 @@ valueToParams ns value =
         Float v ->
             [ ( ns, String.fromFloat v ) ]
 
+        Decimal v ->
+            [ ( ns, v ) ]
+
         Bool True ->
             [ ( ns, "true" ) ]
 

--- a/src/StandardApi/Url/Parser/Query.elm
+++ b/src/StandardApi/Url/Parser/Query.elm
@@ -1,11 +1,1107 @@
-module StandardApi.Url.Parser.Query exposing (..)
+module StandardApi.Url.Parser.Query exposing (parse, parseUrl)
 
-import StandardApi exposing (Query)
+{-| Parse URL query parameters back into a StandardAPI `Query`.
+
+This is the inverse of `StandardApi.Url.Builder.query`.
+
+The parser takes a list of `( String, Type )` pairs that map column names
+to their types. For columns with a known type, the parser decodes values
+accordingly (e.g., integers, booleans, timestamps). For unknown columns,
+values are guessed from the raw string.
+
+If a type is specified for a column and the raw string cannot be parsed as
+that type, the parser returns an error.
+
+@docs parse, parseUrl
+
+-}
+
+import Dict
+import Iso8601
+import StandardApi exposing (Direction(..), Include(..), Limit, Offset, Operation(..), Order, Query, Value(..), emptyQuery, include)
+import StandardApi.Type as Type exposing (Type)
+import Tree exposing (Tree, tree)
+import Url exposing (Url)
+
+
+{-| Parse a query string into a `Query` using the given type mappings.
+
+    import StandardApi exposing (..)
+    import StandardApi.Type as Type
+    import StandardApi.Url.Parser.Query exposing (parse)
+
+    parse [] ""
+    --> Ok emptyQuery
+
+    parse [] "limit=1"
+    --> Ok { emptyQuery | limit = Just 1 }
+
+    parse [ ( "id", Type.Int ) ] "where%5Bid%5D%5Beq%5D=42"
+    --> Ok { emptyQuery | predicate = Just (Eq [ "id" ] (Int 42)) }
+
+-}
+parse : List ( String, Type ) -> String -> Result String Query
+parse types queryString =
+    let
+        params =
+            parseQueryString queryString
+    in
+    parseQuery types [] params
+
+
+{-| Parse a `Url` into a `Query` using the given type mappings.
+
+This is a convenience wrapper around `parse` that extracts the query
+string from a `Url`.
+
+-}
+parseUrl : List ( String, Type ) -> Url -> Result String Query
+parseUrl types url =
+    parse types (Maybe.withDefault "" url.query)
+
+
+parseQueryString : String -> List ( List String, String )
+parseQueryString queryString =
+    if String.isEmpty queryString then
+        []
+
+    else
+        String.split "&" queryString
+            |> List.filterMap
+                (\pair ->
+                    let
+                        ( rawKey, rawValue ) =
+                            splitOnFirstEquals pair
+                    in
+                    if String.isEmpty rawKey then
+                        Nothing
+
+                    else
+                        let
+                            key =
+                                Maybe.withDefault rawKey (Url.percentDecode rawKey)
+
+                            value =
+                                Maybe.withDefault rawValue (Url.percentDecode rawValue)
+                        in
+                        Just ( parseBracketKey key, value )
+                )
+
+
+{-| Split a string on the first `=` character. This handles values that
+contain `=` (e.g., base64-encoded values).
+-}
+splitOnFirstEquals : String -> ( String, String )
+splitOnFirstEquals str =
+    case String.indexes "=" str of
+        [] ->
+            ( str, "" )
+
+        idx :: _ ->
+            ( String.left idx str
+            , String.dropLeft (idx + 1) str
+            )
+
+
+parseBracketKey : String -> List String
+parseBracketKey key =
+    case String.split "[" key of
+        [] ->
+            []
+
+        first :: rest ->
+            first
+                :: List.map
+                    (\segment ->
+                        if String.endsWith "]" segment then
+                            String.dropRight 1 segment
+
+                        else
+                            segment
+                    )
+                    rest
+
+
+parseQuery : List ( String, Type ) -> List String -> List ( List String, String ) -> Result String Query
+parseQuery types ns params =
+    parseLimit ns params
+        |> Result.andThen
+            (\lim ->
+                parseOffset ns params
+                    |> Result.andThen
+                        (\off ->
+                            parseOrder ns params
+                                |> Result.andThen
+                                    (\ord ->
+                                        parsePredicate types ns params
+                                            |> Result.andThen
+                                                (\pred ->
+                                                    parseIncludes types ns params
+                                                        |> Result.map
+                                                            (\incl ->
+                                                                { limit = lim
+                                                                , offset = off
+                                                                , order = ord
+                                                                , predicate = pred
+                                                                , includes = incl
+                                                                }
+                                                            )
+                                                )
+                                    )
+                        )
+            )
+
+
+parseLimit : List String -> List ( List String, String ) -> Result String Limit
+parseLimit ns params =
+    case findValue (ns ++ [ "limit" ]) params of
+        Nothing ->
+            Ok Nothing
+
+        Just str ->
+            case String.toInt str of
+                Just n ->
+                    Ok (Just n)
+
+                Nothing ->
+                    Err ("expected integer for limit, got: " ++ str)
+
+
+parseOffset : List String -> List ( List String, String ) -> Result String Offset
+parseOffset ns params =
+    case findValue (ns ++ [ "offset" ]) params of
+        Nothing ->
+            Ok Nothing
+
+        Just str ->
+            case String.toInt str of
+                Just n ->
+                    Ok (Just n)
+
+                Nothing ->
+                    Err ("expected integer for offset, got: " ++ str)
+
+
+parseOrder : List String -> List ( List String, String ) -> Result String Order
+parseOrder ns params =
+    let
+        prefix =
+            ns ++ [ "order" ]
+
+        results =
+            params
+                |> List.filterMap
+                    (\( keys, value ) ->
+                        case stripPrefix prefix keys of
+                            Just [ column ] ->
+                                Just ( column, value )
+
+                            _ ->
+                                Nothing
+                    )
+    in
+    List.foldl
+        (\( column, value ) acc ->
+            acc
+                |> Result.andThen
+                    (\orders ->
+                        case String.toLower value of
+                            "asc" ->
+                                Ok (orders ++ [ ( column, Asc ) ])
+
+                            "desc" ->
+                                Ok (orders ++ [ ( column, Desc ) ])
+
+                            _ ->
+                                Err ("expected asc or desc for order[" ++ column ++ "], got: " ++ value)
+                    )
+        )
+        (Ok [])
+        results
+
+
+parsePredicate : List ( String, Type ) -> List String -> List ( List String, String ) -> Result String (Maybe Operation)
+parsePredicate types ns params =
+    let
+        prefix =
+            ns ++ [ "where" ]
+
+        whereParams =
+            params
+                |> List.filterMap
+                    (\( keys, value ) ->
+                        stripPrefix prefix keys
+                            |> Maybe.map (\rest -> ( rest, value ))
+                    )
+    in
+    if List.isEmpty whereParams then
+        Ok Nothing
+
+    else
+        parseWhereParams types whereParams
+            |> Result.map Just
+
+
+parseWhereParams : List ( String, Type ) -> List ( List String, String ) -> Result String Operation
+parseWhereParams types params =
+    let
+        hasArrayPrefix =
+            List.any
+                (\( keys, _ ) ->
+                    case keys of
+                        "" :: _ ->
+                            True
+
+                        _ ->
+                            False
+                )
+                params
+    in
+    if hasArrayPrefix then
+        parseCompound types params
+
+    else
+        parseSinglePredicate types params
+
+
+parseCompound : List ( String, Type ) -> List ( List String, String ) -> Result String Operation
+parseCompound types params =
+    let
+        groups =
+            splitByOr params
+    in
+    case groups of
+        [] ->
+            Err "empty compound predicate"
+
+        [ single ] ->
+            parseGroup types single
+                |> Result.andThen combineWithConjunction
+
+        first :: rest ->
+            let
+                foldGroup group accResult =
+                    accResult
+                        |> Result.andThen
+                            (\acc ->
+                                parseGroup types group
+                                    |> Result.andThen combineWithConjunction
+                                    |> Result.map (\g -> Disjunction acc g)
+                            )
+            in
+            parseGroup types first
+                |> Result.andThen combineWithConjunction
+                |> (\firstResult -> List.foldl foldGroup firstResult rest)
+
+
+splitByOr : List ( List String, String ) -> List (List ( List String, String ))
+splitByOr params =
+    let
+        fold ( keys, value ) ( currentGroup, groups ) =
+            if keys == [ "" ] && value == "OR" then
+                ( [], List.reverse currentGroup :: groups )
+
+            else
+                ( ( keys, value ) :: currentGroup, groups )
+
+        ( lastGroup, collectedGroups ) =
+            List.foldl fold ( [], [] ) params
+    in
+    List.reverse (List.reverse lastGroup :: collectedGroups)
+
+
+parseGroup : List ( String, Type ) -> List ( List String, String ) -> Result String (List Operation)
+parseGroup types params =
+    let
+        stripped =
+            List.map
+                (\( keys, value ) ->
+                    case keys of
+                        "" :: rest ->
+                            ( rest, value )
+
+                        _ ->
+                            ( keys, value )
+                )
+                params
+
+        hasNestedArrays =
+            List.any
+                (\( keys, _ ) ->
+                    case keys of
+                        "" :: _ ->
+                            True
+
+                        _ ->
+                            False
+                )
+                stripped
+    in
+    if hasNestedArrays then
+        parseCompound types stripped
+            |> Result.map List.singleton
+
+    else
+        groupIntoOperations types stripped
+
+
+groupIntoOperations : List ( String, Type ) -> List ( List String, String ) -> Result String (List Operation)
+groupIntoOperations types params =
+    List.foldl
+        (\( keys, value ) acc ->
+            acc
+                |> Result.andThen
+                    (\ops ->
+                        parseSingleOp types keys value
+                            |> Result.map (\op -> ops ++ [ op ])
+                    )
+        )
+        (Ok [])
+        params
+
+
+parseSinglePredicate : List ( String, Type ) -> List ( List String, String ) -> Result String Operation
+parseSinglePredicate types params =
+    case params of
+        [ ( keys, value ) ] ->
+            parseSingleOp types keys value
+
+        _ ->
+            groupIntoOperations types params
+                |> Result.andThen combineWithConjunction
+
+
+parseSingleOp : List ( String, Type ) -> List String -> String -> Result String Operation
+parseSingleOp types keys value =
+    case List.reverse keys of
+        "eq" :: columnRev ->
+            let
+                col =
+                    List.reverse columnRev
+            in
+            decodeValue types col value
+                |> Result.map (Eq col)
+
+        "not_eq" :: columnRev ->
+            let
+                col =
+                    List.reverse columnRev
+            in
+            decodeValue types col value
+                |> Result.map (Neq col)
+
+        "lt" :: columnRev ->
+            let
+                col =
+                    List.reverse columnRev
+            in
+            decodeValue types col value
+                |> Result.map (Lt col)
+
+        "lte" :: columnRev ->
+            let
+                col =
+                    List.reverse columnRev
+            in
+            decodeValue types col value
+                |> Result.map (Lte col)
+
+        "gt" :: columnRev ->
+            let
+                col =
+                    List.reverse columnRev
+            in
+            decodeValue types col value
+                |> Result.map (Gt col)
+
+        "gte" :: columnRev ->
+            let
+                col =
+                    List.reverse columnRev
+            in
+            decodeValue types col value
+                |> Result.map (Gte col)
+
+        "ilike" :: columnRev ->
+            let
+                col =
+                    List.reverse columnRev
+            in
+            decodeValue types col value
+                |> Result.map (Ilike col)
+
+        "contains" :: columnRev ->
+            let
+                col =
+                    List.reverse columnRev
+            in
+            decodeValue types col value
+                |> Result.map (Contains col)
+
+        -- where[id][not_in][]=1 -> keys = ["id", "not_in", ""]
+        "" :: "not_in" :: columnRev ->
+            let
+                col =
+                    List.reverse columnRev
+            in
+            decodeValue types col value
+                |> Result.map (\v -> NotIn col [ v ])
+
+        -- where[tags][overlaps][]=elm -> keys = ["tags", "overlaps", ""]
+        "" :: "overlaps" :: columnRev ->
+            let
+                col =
+                    List.reverse columnRev
+            in
+            decodeValue types col value
+                |> Result.map (\v -> Overlaps col [ v ])
+
+        -- where[id][]=1 (In) -> keys = ["id", ""]
+        "" :: columnRev ->
+            let
+                col =
+                    List.reverse columnRev
+            in
+            decodeValue types col value
+                |> Result.map (\v -> In col [ v ])
+
+        _ ->
+            -- Check for Dict values: where[col][op][dictKey]=value
+            case splitOnOperator keys of
+                Just ( col, op, dictKeys ) ->
+                    let
+                        dictValue =
+                            decodeDictLeaf types col dictKeys value
+                    in
+                    dictValue
+                        |> Result.map
+                            (\v ->
+                                case op of
+                                    "eq" ->
+                                        Eq col v
+
+                                    "not_eq" ->
+                                        Neq col v
+
+                                    "lt" ->
+                                        Lt col v
+
+                                    "lte" ->
+                                        Lte col v
+
+                                    "gt" ->
+                                        Gt col v
+
+                                    "gte" ->
+                                        Gte col v
+
+                                    "ilike" ->
+                                        Ilike col v
+
+                                    "contains" ->
+                                        Contains col v
+
+                                    _ ->
+                                        Eq col v
+                            )
+
+                Nothing ->
+                    -- Null / Set: where[column]=false means Null, where[column]=true means Set
+                    if value == "false" then
+                        Ok (Null keys)
+
+                    else if value == "true" then
+                        Ok (Set keys)
+
+                    else
+                        decodeValue types keys value
+                            |> Result.map (Eq keys)
+
+
+{-| Try to find a known operator in the middle of a key path.
+Returns (column, operator, remaining dict keys) if found.
+For example, ["metadata", "eq", "key"] -> Just (["metadata"], "eq", ["key"])
+-}
+splitOnOperator : List String -> Maybe ( List String, String, List String )
+splitOnOperator keys =
+    let
+        operators =
+            [ "eq", "not_eq", "lt", "lte", "gt", "gte", "ilike", "contains" ]
+
+        findOp before remaining =
+            case remaining of
+                [] ->
+                    Nothing
+
+                segment :: rest ->
+                    if List.member segment operators && not (List.isEmpty before) && not (List.isEmpty rest) then
+                        Just ( List.reverse before, segment, rest )
+
+                    else
+                        findOp (segment :: before) rest
+    in
+    findOp [] keys
+
+
+{-| Decode a leaf value within a Dict structure, building the nested Dict.
+For keys ["k1", "k2"] and value "v", produces Dict {"k1": Dict {"k2": String "v"}}
+-}
+decodeDictLeaf : List ( String, Type ) -> List String -> List String -> String -> Result String Value
+decodeDictLeaf types col dictKeys rawValue =
+    let
+        leafValue =
+            guessValue rawValue
+    in
+    Ok (buildDictValue dictKeys leafValue)
+
+
+buildDictValue : List String -> Value -> Value
+buildDictValue dictKeys leafValue =
+    case dictKeys of
+        [] ->
+            leafValue
+
+        key :: rest ->
+            Dict (Dict.singleton key (buildDictValue rest leafValue))
+
+
+{-| Decode a raw string value using the type mappings.
+If the type is known and the value cannot be parsed, returns an error.
+Falls back to heuristic guessing if the column is not in the type list.
+-}
+decodeValue : List ( String, Type ) -> List String -> String -> Result String Value
+decodeValue types column str =
+    case lookupType types column of
+        Just Type.Int ->
+            case String.toInt str of
+                Just i ->
+                    Ok (Int i)
+
+                Nothing ->
+                    Err ("expected integer for " ++ String.join "." column ++ ", got: " ++ str)
+
+        Just Type.Float ->
+            case String.toFloat str of
+                Just f ->
+                    Ok (Float f)
+
+                Nothing ->
+                    Err ("expected float for " ++ String.join "." column ++ ", got: " ++ str)
+
+        Just Type.Bool ->
+            case str of
+                "true" ->
+                    Ok (Bool True)
+
+                "false" ->
+                    Ok (Bool False)
+
+                _ ->
+                    Err ("expected boolean for " ++ String.join "." column ++ ", got: " ++ str)
+
+        Just Type.Posix ->
+            case Iso8601.toTime str of
+                Ok posix ->
+                    Ok (Posix posix)
+
+                Err _ ->
+                    Err ("expected ISO 8601 datetime for " ++ String.join "." column ++ ", got: " ++ str)
+
+        Just Type.String ->
+            Ok (String str)
+
+        Just Type.Dict ->
+            Ok (String str)
+
+        Nothing ->
+            Ok (guessValue str)
+
+
+{-| Look up the type of a column by its path in the type list.
+For simple columns like ["id"], matches on name.
+For nested paths like ["metadata", "key"], uses the first segment.
+-}
+lookupType : List ( String, Type ) -> List String -> Maybe Type
+lookupType types column =
+    case column of
+        first :: _ ->
+            types
+                |> List.filter (\( name, _ ) -> name == first)
+                |> List.map (\( _, t ) -> t)
+                |> List.head
+
+        [] ->
+            Nothing
+
+
+{-| Guess a value type from a raw string when no schema info is available.
+-}
+guessValue : String -> Value
+guessValue str =
+    case String.toInt str of
+        Just i ->
+            Int i
+
+        Nothing ->
+            case String.toFloat str of
+                Just f ->
+                    if String.contains "." str then
+                        Float f
+
+                    else
+                        String str
+
+                Nothing ->
+                    case str of
+                        "true" ->
+                            Bool True
+
+                        "false" ->
+                            Bool False
+
+                        _ ->
+                            String str
+
+
+combineWithConjunction : List Operation -> Result String Operation
+combineWithConjunction ops =
+    case ops of
+        [] ->
+            Err "empty predicate group"
+
+        [ single ] ->
+            Ok single
+
+        first :: rest ->
+            let
+                merged =
+                    first :: rest
+                        |> mergeMultiValueOps
+                        |> mergeDictOps
+            in
+            case merged of
+                [] ->
+                    Err "empty predicate group after merging"
+
+                [ single_ ] ->
+                    Ok single_
+
+                first_ :: rest_ ->
+                    Ok (List.foldl (\op acc -> Conjunction acc op) first_ rest_)
+
+
+{-| Merge consecutive multi-value operations (In, NotIn, Overlaps) that share
+the same column into a single operation with combined value lists.
+-}
+mergeMultiValueOps : List Operation -> List Operation
+mergeMultiValueOps ops =
+    let
+        fold op ( merged, seen ) =
+            case multiValueKey op of
+                Just ( tag, col, vals ) ->
+                    let
+                        key =
+                            ( tag, col )
+                    in
+                    if List.member key seen then
+                        ( appendToMultiValue tag col vals merged, seen )
+
+                    else
+                        ( merged ++ [ op ], key :: seen )
+
+                Nothing ->
+                    ( merged ++ [ op ], seen )
+
+        ( result, _ ) =
+            List.foldl fold ( [], [] ) ops
+    in
+    result
+
+
+multiValueKey : Operation -> Maybe ( String, List String, List Value )
+multiValueKey op =
+    case op of
+        In col vals ->
+            Just ( "In", col, vals )
+
+        NotIn col vals ->
+            Just ( "NotIn", col, vals )
+
+        Overlaps col vals ->
+            Just ( "Overlaps", col, vals )
+
+        _ ->
+            Nothing
+
+
+appendToMultiValue : String -> List String -> List Value -> List Operation -> List Operation
+appendToMultiValue tag col vals =
+    List.map
+        (\existing ->
+            case ( tag, existing ) of
+                ( "In", In ecol evals ) ->
+                    if ecol == col then
+                        In ecol (evals ++ vals)
+
+                    else
+                        existing
+
+                ( "NotIn", NotIn ecol evals ) ->
+                    if ecol == col then
+                        NotIn ecol (evals ++ vals)
+
+                    else
+                        existing
+
+                ( "Overlaps", Overlaps ecol evals ) ->
+                    if ecol == col then
+                        Overlaps ecol (evals ++ vals)
+
+                    else
+                        existing
+
+                _ ->
+                    existing
+        )
+
+
+{-| Merge Dict-valued operations on the same column into a single operation.
+For example, Eq ["meta"] (Dict {"k1": v1}) and Eq ["meta"] (Dict {"k2": v2})
+become Eq ["meta"] (Dict {"k1": v1, "k2": v2}).
+-}
+mergeDictOps : List Operation -> List Operation
+mergeDictOps ops =
+    let
+        dictKey op =
+            case op of
+                Eq col (Dict _) ->
+                    Just ( "Eq", col )
+
+                Neq col (Dict _) ->
+                    Just ( "Neq", col )
+
+                Lt col (Dict _) ->
+                    Just ( "Lt", col )
+
+                Lte col (Dict _) ->
+                    Just ( "Lte", col )
+
+                Gt col (Dict _) ->
+                    Just ( "Gt", col )
+
+                Gte col (Dict _) ->
+                    Just ( "Gte", col )
+
+                _ ->
+                    Nothing
+
+        mergeDicts d1 d2 =
+            Dict.foldl Dict.insert d1 d2
+
+        extractDict op =
+            case op of
+                Eq _ (Dict d) ->
+                    Just d
+
+                Neq _ (Dict d) ->
+                    Just d
+
+                Lt _ (Dict d) ->
+                    Just d
+
+                Lte _ (Dict d) ->
+                    Just d
+
+                Gt _ (Dict d) ->
+                    Just d
+
+                Gte _ (Dict d) ->
+                    Just d
+
+                _ ->
+                    Nothing
+
+        updateWithDict tag col newDict =
+            List.map
+                (\existing ->
+                    case ( dictKey existing, extractDict existing ) of
+                        ( Just ( t, c ), Just d ) ->
+                            if t == tag && c == col then
+                                let
+                                    merged =
+                                        mergeDicts d newDict
+                                in
+                                case tag of
+                                    "Eq" ->
+                                        Eq col (Dict merged)
+
+                                    "Neq" ->
+                                        Neq col (Dict merged)
+
+                                    "Lt" ->
+                                        Lt col (Dict merged)
+
+                                    "Lte" ->
+                                        Lte col (Dict merged)
+
+                                    "Gt" ->
+                                        Gt col (Dict merged)
+
+                                    "Gte" ->
+                                        Gte col (Dict merged)
+
+                                    _ ->
+                                        existing
+
+                            else
+                                existing
+
+                        _ ->
+                            existing
+                )
+
+        fold op ( result, seen ) =
+            case ( dictKey op, extractDict op ) of
+                ( Just key, Just d ) ->
+                    if List.member key seen then
+                        ( updateWithDict (Tuple.first key) (Tuple.second key) d result, seen )
+
+                    else
+                        ( result ++ [ op ], key :: seen )
+
+                _ ->
+                    ( result ++ [ op ], seen )
+
+        ( finalResult, _ ) =
+            List.foldl fold ( [], [] ) ops
+    in
+    finalResult
+
+
+parseIncludes : List ( String, Type ) -> List String -> List ( List String, String ) -> Result String (List (Tree Include))
+parseIncludes types ns params =
+    let
+        prefix =
+            ns ++ [ "include" ]
+
+        includeParams =
+            params
+                |> List.filterMap
+                    (\( keys, value ) ->
+                        stripPrefix prefix keys
+                            |> Maybe.map (\rest -> ( rest, value ))
+                    )
+
+        includeNames =
+            includeParams
+                |> List.filterMap
+                    (\( keys, _ ) ->
+                        List.head keys
+                    )
+                |> unique
+    in
+    List.foldl
+        (\name acc ->
+            acc
+                |> Result.andThen
+                    (\trees ->
+                        let
+                            scopedParams =
+                                includeParams
+                                    |> List.filterMap
+                                        (\( keys, value ) ->
+                                            case keys of
+                                                first :: rest ->
+                                                    if first == name then
+                                                        Just ( rest, value )
+
+                                                    else
+                                                        Nothing
+
+                                                [] ->
+                                                    Nothing
+                                        )
+
+                            isSimple =
+                                scopedParams == [ ( [], "true" ) ]
+                        in
+                        if isSimple then
+                            Ok (trees ++ [ tree (include ( name, emptyQuery )) [] ])
+
+                        else
+                            parseSubIncludes types name scopedParams
+                                |> Result.andThen
+                                    (\subIncludeResult ->
+                                        parseSubQuery types scopedParams subIncludeResult.consumedKeys
+                                            |> Result.map
+                                                (\subQ ->
+                                                    trees ++ [ tree (include ( name, subQ )) subIncludeResult.trees ]
+                                                )
+                                    )
+                    )
+        )
+        (Ok [])
+        includeNames
+
+
+type alias SubIncludeResult =
+    { trees : List (Tree Include)
+    , consumedKeys : List (List String)
+    }
+
+
+parseSubIncludes : List ( String, Type ) -> String -> List ( List String, String ) -> Result String SubIncludeResult
+parseSubIncludes types _ scopedParams =
+    let
+        knownQueryPrefixes =
+            [ "limit", "offset", "order", "where" ]
+
+        subIncludeParams =
+            scopedParams
+                |> List.filter
+                    (\( keys, _ ) ->
+                        case keys of
+                            first :: _ ->
+                                not (List.member first knownQueryPrefixes)
+
+                            [] ->
+                                False
+                    )
+
+        subIncludeNames =
+            subIncludeParams
+                |> List.filterMap
+                    (\( keys, _ ) ->
+                        List.head keys
+                    )
+                |> unique
+
+        consumed =
+            List.map (\( keys, _ ) -> keys) subIncludeParams
+    in
+    List.foldl
+        (\name acc ->
+            acc
+                |> Result.andThen
+                    (\trees ->
+                        let
+                            innerParams =
+                                subIncludeParams
+                                    |> List.filterMap
+                                        (\( keys, value ) ->
+                                            case keys of
+                                                first :: rest ->
+                                                    if first == name then
+                                                        Just ( rest, value )
+
+                                                    else
+                                                        Nothing
+
+                                                [] ->
+                                                    Nothing
+                                        )
+
+                            isSimple =
+                                innerParams == [ ( [], "true" ) ]
+                        in
+                        if isSimple then
+                            Ok (trees ++ [ tree (include ( name, emptyQuery )) [] ])
+
+                        else
+                            parseSubIncludes types name innerParams
+                                |> Result.andThen
+                                    (\subResult ->
+                                        parseSubQuery types innerParams subResult.consumedKeys
+                                            |> Result.map
+                                                (\subQ ->
+                                                    trees ++ [ tree (include ( name, subQ )) subResult.trees ]
+                                                )
+                                    )
+                    )
+        )
+        (Ok [])
+        subIncludeNames
+        |> Result.map (\trees -> { trees = trees, consumedKeys = consumed })
+
+
+parseSubQuery : List ( String, Type ) -> List ( List String, String ) -> List (List String) -> Result String Query
+parseSubQuery types scopedParams consumedKeys =
+    let
+        queryParams =
+            scopedParams
+                |> List.filter
+                    (\( keys, _ ) ->
+                        not (List.member keys consumedKeys)
+                    )
+    in
+    parseLimit [] queryParams
+        |> Result.andThen
+            (\lim ->
+                parseOffset [] queryParams
+                    |> Result.andThen
+                        (\off ->
+                            parseOrder [] queryParams
+                                |> Result.andThen
+                                    (\ord ->
+                                        parsePredicate types [] queryParams
+                                            |> Result.map
+                                                (\pred ->
+                                                    { limit = lim
+                                                    , offset = off
+                                                    , order = ord
+                                                    , predicate = pred
+                                                    , includes = []
+                                                    }
+                                                )
+                                    )
+                        )
+            )
 
 
 
--- TODO: Implement query string parser that converts URL query parameters
--- back into a Query type (inverse of StandardApi.Url.Builder).
---
--- query : Parser Query
--- query =
+-- Helpers
+
+
+findValue : List String -> List ( List String, String ) -> Maybe String
+findValue target params =
+    params
+        |> List.filterMap
+            (\( keys, value ) ->
+                if keys == target then
+                    Just value
+
+                else
+                    Nothing
+            )
+        |> List.head
+
+
+stripPrefix : List String -> List String -> Maybe (List String)
+stripPrefix prefix keys =
+    case ( prefix, keys ) of
+        ( [], rest ) ->
+            Just rest
+
+        ( p :: ps, k :: ks ) ->
+            if p == k then
+                stripPrefix ps ks
+
+            else
+                Nothing
+
+        _ ->
+            Nothing
+
+
+unique : List String -> List String
+unique list =
+    List.foldl
+        (\item acc ->
+            if List.member item acc then
+                acc
+
+            else
+                acc ++ [ item ]
+        )
+        []
+        list

--- a/src/StandardApi/Url/Parser/Query.elm
+++ b/src/StandardApi/Url/Parser/Query.elm
@@ -675,7 +675,8 @@ combineWithConjunction ops =
         first :: rest ->
             let
                 merged =
-                    first :: rest
+                    first
+                        :: rest
                         |> mergeMultiValueOps
                         |> mergeDictOps
             in

--- a/src/StandardApi/Url/Parser/Query.elm
+++ b/src/StandardApi/Url/Parser/Query.elm
@@ -193,8 +193,8 @@ parseOrder ns params =
                 |> List.filterMap
                     (\( keys, value ) ->
                         case stripPrefix prefix keys of
-                            Just [ column ] ->
-                                Just ( column, value )
+                            Just (first :: rest) ->
+                                Just ( String.join "." (first :: rest), value )
 
                             _ ->
                                 Nothing

--- a/src/StandardApi/Url/Parser/Query.elm
+++ b/src/StandardApi/Url/Parser/Query.elm
@@ -607,6 +607,9 @@ decodeValue types column str =
                 Err _ ->
                     Err ("expected ISO 8601 datetime for " ++ String.join "." column ++ ", got: " ++ str)
 
+        Just Type.Decimal ->
+            Ok (Decimal str)
+
         Just Type.String ->
             Ok (String str)
 

--- a/tests/Url/ParserQueryTest.elm
+++ b/tests/Url/ParserQueryTest.elm
@@ -1,0 +1,876 @@
+module Url.ParserQueryTest exposing (..)
+
+import Dict
+import Expect
+import Iso8601
+import StandardApi exposing (..)
+import StandardApi.Type as Type
+import StandardApi.Url.Builder as Builder
+import StandardApi.Url.Parser.Query as Parser
+import Test exposing (..)
+import Time
+import Tree exposing (tree)
+import Url
+
+
+{-| No type mappings -- parser falls back to guessing types.
+-}
+noTypes : List ( String, Type.Type )
+noTypes =
+    []
+
+
+{-| Type mappings for testing schema-driven decoding.
+-}
+typedColumns : List ( String, Type.Type )
+typedColumns =
+    [ ( "id", Type.Int )
+    , ( "name", Type.String )
+    , ( "age", Type.Int )
+    , ( "price", Type.Float )
+    , ( "active", Type.Bool )
+    , ( "created_at", Type.Posix )
+    , ( "tags", Type.String )
+    , ( "region_ids", Type.Int )
+    , ( "deleted_at", Type.Posix )
+    , ( "status", Type.String )
+    , ( "token", Type.String )
+    , ( "version", Type.Int )
+    , ( "login_count", Type.Int )
+    ]
+
+
+suite : Test
+suite =
+    describe "StandardApi.Url.Parser.Query"
+        [ basicTests
+        , orderTests
+        , predicateTests
+        , schemaDecodingTests
+        , includeTests
+        , roundtripTests
+        , edgeCaseTests
+        , strictParsingTests
+        , parseUrlTests
+        , modelToTypesTests
+        , dictTests
+        ]
+
+
+basicTests : Test
+basicTests =
+    describe "basic"
+        [ test "empty query string" <|
+            \() ->
+                Parser.parse noTypes ""
+                    |> Expect.equal (Ok emptyQuery)
+        , test "limit" <|
+            \() ->
+                Parser.parse noTypes "limit=1"
+                    |> Expect.equal (Ok { emptyQuery | limit = Just 1 })
+        , test "offset" <|
+            \() ->
+                Parser.parse noTypes "offset=5"
+                    |> Expect.equal (Ok { emptyQuery | offset = Just 5 })
+        , test "limit and offset" <|
+            \() ->
+                Parser.parse noTypes "limit=10&offset=20"
+                    |> Expect.equal (Ok { emptyQuery | limit = Just 10, offset = Just 20 })
+        ]
+
+
+orderTests : Test
+orderTests =
+    describe "order"
+        [ test "asc" <|
+            \() ->
+                Parser.parse noTypes "order%5Bid%5D=asc"
+                    |> Expect.equal (Ok { emptyQuery | order = [ ( "id", Asc ) ] })
+        , test "desc" <|
+            \() ->
+                Parser.parse noTypes "order%5Bid%5D=desc"
+                    |> Expect.equal (Ok { emptyQuery | order = [ ( "id", Desc ) ] })
+        , test "multiple orders" <|
+            \() ->
+                Parser.parse noTypes "order%5Bid%5D=asc&order%5Bname%5D=desc"
+                    |> Expect.equal (Ok { emptyQuery | order = [ ( "id", Asc ), ( "name", Desc ) ] })
+        ]
+
+
+predicateTests : Test
+predicateTests =
+    describe "predicate"
+        [ test "eq string" <|
+            \() ->
+                Parser.parse noTypes "where%5Bname%5D%5Beq%5D=standardapi"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "name" ] (StandardApi.String "standardapi")) })
+        , test "eq int" <|
+            \() ->
+                Parser.parse noTypes "where%5Bid%5D%5Beq%5D=42"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "id" ] (StandardApi.Int 42)) })
+        , test "neq" <|
+            \() ->
+                Parser.parse noTypes "where%5Bname%5D%5Bnot_eq%5D=standardapi"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Neq [ "name" ] (StandardApi.String "standardapi")) })
+        , test "lt" <|
+            \() ->
+                Parser.parse noTypes "where%5Bage%5D%5Blt%5D=30"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Lt [ "age" ] (StandardApi.Int 30)) })
+        , test "lte" <|
+            \() ->
+                Parser.parse noTypes "where%5Bage%5D%5Blte%5D=30"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Lte [ "age" ] (StandardApi.Int 30)) })
+        , test "gt" <|
+            \() ->
+                Parser.parse noTypes "where%5Bage%5D%5Bgt%5D=18"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Gt [ "age" ] (StandardApi.Int 18)) })
+        , test "gte" <|
+            \() ->
+                Parser.parse noTypes "where%5Bage%5D%5Bgte%5D=18"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Gte [ "age" ] (StandardApi.Int 18)) })
+        , test "ilike" <|
+            \() ->
+                Parser.parse noTypes "where%5Bname%5D%5Bilike%5D=%25api%25"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Ilike [ "name" ] (StandardApi.String "%api%")) })
+        , test "null" <|
+            \() ->
+                Parser.parse noTypes "where%5Bdeleted_at%5D=false"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Null [ "deleted_at" ]) })
+        , test "set" <|
+            \() ->
+                Parser.parse noTypes "where%5Bdeleted_at%5D=true"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Set [ "deleted_at" ]) })
+        , test "in" <|
+            \() ->
+                Parser.parse noTypes "where%5Bid%5D%5B%5D=1&where%5Bid%5D%5B%5D=2&where%5Bid%5D%5B%5D=3"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (In [ "id" ] [ StandardApi.Int 1, StandardApi.Int 2, StandardApi.Int 3 ]) })
+        , test "not_in" <|
+            \() ->
+                Parser.parse noTypes "where%5Bid%5D%5Bnot_in%5D%5B%5D=1&where%5Bid%5D%5Bnot_in%5D%5B%5D=2"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (NotIn [ "id" ] [ StandardApi.Int 1, StandardApi.Int 2 ]) })
+        , test "overlaps" <|
+            \() ->
+                Parser.parse noTypes "where%5Btags%5D%5Boverlaps%5D%5B%5D=elm&where%5Btags%5D%5Boverlaps%5D%5B%5D=api"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Overlaps [ "tags" ] [ StandardApi.String "elm", StandardApi.String "api" ]) })
+        , test "contains" <|
+            \() ->
+                Parser.parse noTypes "where%5Bregion_ids%5D%5Bcontains%5D=20106"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Contains [ "region_ids" ] (StandardApi.Int 20106)) })
+        , test "float value" <|
+            \() ->
+                Parser.parse noTypes "where%5Bprice%5D%5Bgte%5D=9.99"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Gte [ "price" ] (StandardApi.Float 9.99)) })
+        , test "bool value true" <|
+            \() ->
+                Parser.parse noTypes "where%5Bactive%5D%5Beq%5D=true"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "active" ] (StandardApi.Bool True)) })
+        , test "bool value false" <|
+            \() ->
+                Parser.parse noTypes "where%5Bactive%5D%5Beq%5D=false"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "active" ] (StandardApi.Bool False)) })
+        , test "conjunction" <|
+            \() ->
+                Parser.parse noTypes "where%5B%5D%5Bname%5D%5Beq%5D=standardapi&where%5B%5D%5Bversion%5D%5Beq%5D=1"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | predicate =
+                                    Just
+                                        (Conjunction
+                                            (Eq [ "name" ] (StandardApi.String "standardapi"))
+                                            (Eq [ "version" ] (StandardApi.Int 1))
+                                        )
+                            }
+                        )
+        , test "conjunction id and name" <|
+            \() ->
+                Parser.parse noTypes "where%5B%5D%5Bid%5D%5Beq%5D=1&where%5B%5D%5Bname%5D%5Beq%5D=Test"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | predicate =
+                                    Just
+                                        (Conjunction
+                                            (Eq [ "id" ] (StandardApi.Int 1))
+                                            (Eq [ "name" ] (StandardApi.String "Test"))
+                                        )
+                            }
+                        )
+        , test "disjunction" <|
+            \() ->
+                Parser.parse noTypes "where%5B%5D%5Bname%5D%5Beq%5D=foo&where%5B%5D=OR&where%5B%5D%5Bname%5D%5Beq%5D=bar"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | predicate =
+                                    Just
+                                        (Disjunction
+                                            (Eq [ "name" ] (StandardApi.String "foo"))
+                                            (Eq [ "name" ] (StandardApi.String "bar"))
+                                        )
+                            }
+                        )
+        , test "nested column path" <|
+            \() ->
+                Parser.parse noTypes "where%5Bmetadata%5D%5Bkey%5D%5Beq%5D=name"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "metadata", "key" ] (StandardApi.String "name")) })
+        ]
+
+
+schemaDecodingTests : Test
+schemaDecodingTests =
+    describe "schema-driven decoding"
+        [ test "int attribute decoded as Int" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bid%5D%5Beq%5D=42"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "id" ] (StandardApi.Int 42)) })
+        , test "string attribute keeps numeric string as String" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bname%5D%5Beq%5D=123"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "name" ] (StandardApi.String "123")) })
+        , test "float attribute decoded as Float" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bprice%5D%5Bgte%5D=9.99"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Gte [ "price" ] (StandardApi.Float 9.99)) })
+        , test "float attribute decodes integer string as Float" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bprice%5D%5Bgte%5D=10"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Gte [ "price" ] (StandardApi.Float 10.0)) })
+        , test "bool attribute decoded as Bool" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bactive%5D%5Beq%5D=true"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "active" ] (StandardApi.Bool True)) })
+        , test "posix attribute decoded as Posix" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bcreated_at%5D%5Bgte%5D=1970-01-01T00%3A00%3A00.000Z"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | predicate =
+                                    Just (Gte [ "created_at" ] (StandardApi.Posix (Time.millisToPosix 0)))
+                            }
+                        )
+        , test "unknown attribute falls back to guessing" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bunknown%5D%5Beq%5D=42"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "unknown" ] (StandardApi.Int 42)) })
+        , test "int attribute with non-numeric value returns error" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bid%5D%5Beq%5D=abc"
+                    |> Expect.err
+        , test "float attribute with non-numeric value returns error" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bprice%5D%5Bgte%5D=abc"
+                    |> Expect.err
+        , test "bool attribute with non-boolean value returns error" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bactive%5D%5Beq%5D=maybe"
+                    |> Expect.err
+        , test "posix attribute with invalid date returns error" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bcreated_at%5D%5Bgte%5D=not-a-date"
+                    |> Expect.err
+        , test "conjunction with mixed types uses schema" <|
+            \() ->
+                Parser.parse typedColumns "where%5B%5D%5Bid%5D%5Beq%5D=1&where%5B%5D%5Bname%5D%5Beq%5D=1"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | predicate =
+                                    Just
+                                        (Conjunction
+                                            (Eq [ "id" ] (StandardApi.Int 1))
+                                            (Eq [ "name" ] (StandardApi.String "1"))
+                                        )
+                            }
+                        )
+        ]
+
+
+includeTests : Test
+includeTests =
+    describe "include"
+        [ test "simple" <|
+            \() ->
+                Parser.parse noTypes "include%5Bauthor%5D=true"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | includes =
+                                    [ tree (include ( "author", emptyQuery )) [] ]
+                            }
+                        )
+        , test "multiple" <|
+            \() ->
+                Parser.parse noTypes "include%5Bauthor%5D=true&include%5Bcontributors%5D=true"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | includes =
+                                    [ tree (include ( "author", emptyQuery )) []
+                                    , tree (include ( "contributors", emptyQuery )) []
+                                    ]
+                            }
+                        )
+        , test "with limit" <|
+            \() ->
+                Parser.parse noTypes "include%5Bcontributors%5D%5Blimit%5D=1"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | includes =
+                                    [ tree (include ( "contributors", { emptyQuery | limit = Just 1 } )) [] ]
+                            }
+                        )
+        , test "with offset" <|
+            \() ->
+                Parser.parse noTypes "include%5Bcontributors%5D%5Boffset%5D=1"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | includes =
+                                    [ tree (include ( "contributors", { emptyQuery | offset = Just 1 } )) [] ]
+                            }
+                        )
+        , test "with order" <|
+            \() ->
+                Parser.parse noTypes "include%5Bcontributors%5D%5Border%5D%5Bid%5D=asc"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | includes =
+                                    [ tree (include ( "contributors", { emptyQuery | order = [ ( "id", Asc ) ] } )) [] ]
+                            }
+                        )
+        , test "with where" <|
+            \() ->
+                Parser.parse noTypes "include%5Bcontributors%5D%5Bwhere%5D%5Bname%5D%5Beq%5D=elon"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | includes =
+                                    [ tree
+                                        (include
+                                            ( "contributors"
+                                            , { emptyQuery | predicate = Just (Eq [ "name" ] (StandardApi.String "elon")) }
+                                            )
+                                        )
+                                        []
+                                    ]
+                            }
+                        )
+        , test "with where conjunction" <|
+            \() ->
+                Parser.parse noTypes "include%5Bcontributors%5D%5Bwhere%5D%5B%5D%5Bname%5D%5Beq%5D=elon&include%5Bcontributors%5D%5Bwhere%5D%5B%5D%5Borg%5D%5Beq%5D=tesla"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | includes =
+                                    [ tree
+                                        (include
+                                            ( "contributors"
+                                            , { emptyQuery
+                                                | predicate =
+                                                    Just
+                                                        (Conjunction
+                                                            (Eq [ "name" ] (StandardApi.String "elon"))
+                                                            (Eq [ "org" ] (StandardApi.String "tesla"))
+                                                        )
+                                              }
+                                            )
+                                        )
+                                        []
+                                    ]
+                            }
+                        )
+        , test "nested" <|
+            \() ->
+                Parser.parse noTypes "include%5Bauthor%5D%5Borganization%5D=true"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | includes =
+                                    [ tree
+                                        (include ( "author", emptyQuery ))
+                                        [ tree (include ( "organization", emptyQuery )) [] ]
+                                    ]
+                            }
+                        )
+        , test "nested with subquery" <|
+            \() ->
+                Parser.parse noTypes "include%5Bauthor%5D%5Blimit%5D=1&include%5Bauthor%5D%5Borganization%5D=true"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | includes =
+                                    [ tree
+                                        (include ( "author", { emptyQuery | limit = Just 1 } ))
+                                        [ tree (include ( "organization", emptyQuery )) [] ]
+                                    ]
+                            }
+                        )
+        ]
+
+
+roundtripTests : Test
+roundtripTests =
+    describe "roundtrip"
+        [ test "empty query" <|
+            \() ->
+                roundtrip emptyQuery
+        , test "with limit" <|
+            \() ->
+                roundtrip { emptyQuery | limit = Just 5 }
+        , test "with offset" <|
+            \() ->
+                roundtrip { emptyQuery | offset = Just 10 }
+        , test "with order asc" <|
+            \() ->
+                roundtrip { emptyQuery | order = [ ( "created_at", Asc ) ] }
+        , test "with order desc" <|
+            \() ->
+                roundtrip { emptyQuery | order = [ ( "created_at", Desc ) ] }
+        , test "with eq int" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Eq [ "id" ] (StandardApi.Int 42)) }
+        , test "with eq string" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Eq [ "name" ] (StandardApi.String "test")) }
+        , test "with neq" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Neq [ "name" ] (StandardApi.String "bad")) }
+        , test "with lt" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Lt [ "age" ] (StandardApi.Int 30)) }
+        , test "with lte" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Lte [ "age" ] (StandardApi.Int 30)) }
+        , test "with gt" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Gt [ "age" ] (StandardApi.Int 18)) }
+        , test "with gte" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Gte [ "age" ] (StandardApi.Int 18)) }
+        , test "with ilike" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Ilike [ "name" ] (StandardApi.String "%api%")) }
+        , test "with contains" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Contains [ "region_ids" ] (StandardApi.Int 20106)) }
+        , test "with null" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Null [ "deleted_at" ]) }
+        , test "with set" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Set [ "deleted_at" ]) }
+        , test "with not_in" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (NotIn [ "id" ] [ StandardApi.Int 1, StandardApi.Int 2 ]) }
+        , test "with overlaps" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Overlaps [ "tags" ] [ StandardApi.String "elm", StandardApi.String "api" ]) }
+        , test "with in" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (In [ "id" ] [ StandardApi.Int 1, StandardApi.Int 2, StandardApi.Int 3 ]) }
+        , test "with conjunction" <|
+            \() ->
+                roundtrip
+                    { emptyQuery
+                        | predicate =
+                            Just
+                                (Conjunction
+                                    (Eq [ "id" ] (StandardApi.Int 1))
+                                    (Eq [ "name" ] (StandardApi.String "Test"))
+                                )
+                    }
+        , test "with disjunction" <|
+            \() ->
+                roundtrip
+                    { emptyQuery
+                        | predicate =
+                            Just
+                                (Disjunction
+                                    (Eq [ "name" ] (StandardApi.String "foo"))
+                                    (Eq [ "name" ] (StandardApi.String "bar"))
+                                )
+                    }
+        , test "with float value" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Gte [ "price" ] (StandardApi.Float 9.99)) }
+        , test "with bool true value" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Eq [ "active" ] (StandardApi.Bool True)) }
+        , test "with bool false value" <|
+            \() ->
+                roundtrip { emptyQuery | predicate = Just (Eq [ "active" ] (StandardApi.Bool False)) }
+        , test "with simple include" <|
+            \() ->
+                roundtrip
+                    { emptyQuery
+                        | includes = [ tree (include ( "author", emptyQuery )) [] ]
+                    }
+        , test "with multiple includes" <|
+            \() ->
+                roundtrip
+                    { emptyQuery
+                        | includes =
+                            [ tree (include ( "author", emptyQuery )) []
+                            , tree (include ( "contributors", emptyQuery )) []
+                            ]
+                    }
+        , test "with include with limit" <|
+            \() ->
+                roundtrip
+                    { emptyQuery
+                        | includes = [ tree (include ( "users", { emptyQuery | limit = Just 3 } )) [] ]
+                    }
+        , test "with include with offset" <|
+            \() ->
+                roundtrip
+                    { emptyQuery
+                        | includes = [ tree (include ( "users", { emptyQuery | offset = Just 5 } )) [] ]
+                    }
+        , test "with include with order" <|
+            \() ->
+                roundtrip
+                    { emptyQuery
+                        | includes = [ tree (include ( "users", { emptyQuery | order = [ ( "id", Asc ) ] } )) [] ]
+                    }
+        , test "with include with where" <|
+            \() ->
+                roundtrip
+                    { emptyQuery
+                        | includes =
+                            [ tree
+                                (include
+                                    ( "users"
+                                    , { emptyQuery | predicate = Just (Eq [ "name" ] (StandardApi.String "test")) }
+                                    )
+                                )
+                                []
+                            ]
+                    }
+        , test "with nested include" <|
+            \() ->
+                roundtrip
+                    { emptyQuery
+                        | includes =
+                            [ tree
+                                (include ( "author", emptyQuery ))
+                                [ tree (include ( "organization", emptyQuery )) [] ]
+                            ]
+                    }
+        , test "with nested include via includes field parses as tree children" <|
+            \() ->
+                let
+                    input =
+                        { emptyQuery
+                            | includes =
+                                [ tree
+                                    (include
+                                        ( "author"
+                                        , { emptyQuery
+                                            | includes =
+                                                [ tree (include ( "organization", emptyQuery )) [] ]
+                                          }
+                                        )
+                                    )
+                                    []
+                                ]
+                        }
+
+                    expected =
+                        { emptyQuery
+                            | includes =
+                                [ tree
+                                    (include ( "author", emptyQuery ))
+                                    [ tree (include ( "organization", emptyQuery )) [] ]
+                                ]
+                        }
+
+                    url =
+                        Builder.absolute [ "test" ] input
+
+                    queryString =
+                        case String.split "?" url of
+                            [ _, qs ] ->
+                                qs
+
+                            _ ->
+                                ""
+                in
+                Parser.parse noTypes queryString
+                    |> Expect.equal (Ok expected)
+        , test "with complex query" <|
+            \() ->
+                roundtrip
+                    { limit = Just 10
+                    , offset = Just 20
+                    , order = [ ( "created_at", Desc ) ]
+                    , predicate = Just (Eq [ "status" ] (StandardApi.String "active"))
+                    , includes =
+                        [ tree (include ( "author", emptyQuery )) []
+                        , tree (include ( "tags", { emptyQuery | limit = Just 5 } )) []
+                        ]
+                    }
+        ]
+
+
+edgeCaseTests : Test
+edgeCaseTests =
+    describe "edge cases"
+        [ test "value containing equals sign" <|
+            \() ->
+                Parser.parse noTypes "where%5Btoken%5D%5Beq%5D=abc%3Ddef"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "token" ] (StandardApi.String "abc=def")) })
+        , test "error result type is Result" <|
+            \() ->
+                case Parser.parse noTypes "" of
+                    Ok q ->
+                        q |> Expect.equal emptyQuery
+
+                    Err _ ->
+                        Expect.fail "should not fail on empty string"
+        , test "empty key is ignored" <|
+            \() ->
+                Parser.parse noTypes "=value"
+                    |> Expect.equal (Ok emptyQuery)
+        , test "key with empty value" <|
+            \() ->
+                Parser.parse noTypes "where%5Bname%5D%5Beq%5D="
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "name" ] (StandardApi.String "")) })
+        , test "key with no equals treated as empty value" <|
+            \() ->
+                Parser.parse noTypes "limit"
+                    |> Expect.err
+        ]
+
+
+{-| Test that building a URL and parsing it back gives the same Query.
+Uses no type mappings so the parser falls back to heuristic guessing,
+which matches how the builder serializes values.
+-}
+roundtrip : Query -> Expect.Expectation
+roundtrip query =
+    let
+        url =
+            Builder.absolute [ "test" ] query
+
+        queryString =
+            case String.split "?" url of
+                [ _, qs ] ->
+                    qs
+
+                _ ->
+                    ""
+    in
+    Parser.parse noTypes queryString
+        |> Expect.equal (Ok query)
+
+
+typedRoundtrip : List ( String, Type.Type ) -> Query -> Expect.Expectation
+typedRoundtrip types query =
+    let
+        url =
+            Builder.absolute [ "test" ] query
+
+        queryString =
+            case String.split "?" url of
+                [ _, qs ] ->
+                    qs
+
+                _ ->
+                    ""
+    in
+    Parser.parse types queryString
+        |> Expect.equal (Ok query)
+
+
+strictParsingTests : Test
+strictParsingTests =
+    describe "strict parsing"
+        [ test "garbage limit returns error" <|
+            \() ->
+                Parser.parse noTypes "limit=abc"
+                    |> Expect.err
+        , test "garbage offset returns error" <|
+            \() ->
+                Parser.parse noTypes "offset=abc"
+                    |> Expect.err
+        , test "invalid order direction returns error" <|
+            \() ->
+                Parser.parse noTypes "order%5Bid%5D=sideways"
+                    |> Expect.err
+        , test "limit error message is descriptive" <|
+            \() ->
+                Parser.parse noTypes "limit=abc"
+                    |> Expect.equal (Err "expected integer for limit, got: abc")
+        , test "offset error message is descriptive" <|
+            \() ->
+                Parser.parse noTypes "offset=xyz"
+                    |> Expect.equal (Err "expected integer for offset, got: xyz")
+        , test "order error message is descriptive" <|
+            \() ->
+                Parser.parse noTypes "order%5Bid%5D=sideways"
+                    |> Expect.equal (Err "expected asc or desc for order[id], got: sideways")
+        , test "posix roundtrip with typed columns" <|
+            \() ->
+                typedRoundtrip typedColumns
+                    { emptyQuery
+                        | predicate =
+                            Just (Gte [ "created_at" ] (StandardApi.Posix (Time.millisToPosix 0)))
+                    }
+        , test "int type mismatch error message" <|
+            \() ->
+                Parser.parse typedColumns "where%5Bid%5D%5Beq%5D=abc"
+                    |> Expect.equal (Err "expected integer for id, got: abc")
+        , test "sub-include predicate error propagates" <|
+            \() ->
+                Parser.parse typedColumns "include%5Bauthor%5D%5Bwhere%5D%5Bid%5D%5Beq%5D=abc"
+                    |> Expect.err
+        , test "sub-include garbage limit propagates error" <|
+            \() ->
+                Parser.parse noTypes "include%5Bauthor%5D%5Blimit%5D=abc"
+                    |> Expect.err
+        ]
+
+
+parseUrlTests : Test
+parseUrlTests =
+    describe "parseUrl"
+        [ test "parses query from Url" <|
+            \() ->
+                let
+                    url =
+                        { protocol = Url.Https
+                        , host = "example.com"
+                        , port_ = Nothing
+                        , path = "/test"
+                        , query = Just "limit=5"
+                        , fragment = Nothing
+                        }
+                in
+                Parser.parseUrl noTypes url
+                    |> Expect.equal (Ok { emptyQuery | limit = Just 5 })
+        , test "empty query in Url" <|
+            \() ->
+                let
+                    url =
+                        { protocol = Url.Https
+                        , host = "example.com"
+                        , port_ = Nothing
+                        , path = "/test"
+                        , query = Nothing
+                        , fragment = Nothing
+                        }
+                in
+                Parser.parseUrl noTypes url
+                    |> Expect.equal (Ok emptyQuery)
+        ]
+
+
+modelToTypesTests : Test
+modelToTypesTests =
+    describe "modelToTypes"
+        [ test "converts model attributes to type list" <|
+            \() ->
+                let
+                    model =
+                        { name = "test"
+                        , attributes =
+                            [ { name = "id", type_ = Type.Int, default = Nothing, primaryKey = True, null = False, array = False, comment = "" }
+                            , { name = "name", type_ = Type.String, default = Nothing, primaryKey = False, null = False, array = False, comment = "" }
+                            ]
+                        , comment = ""
+                        }
+                in
+                modelToTypes model
+                    |> Expect.equal [ ( "id", Type.Int ), ( "name", Type.String ) ]
+        , test "empty model gives empty list" <|
+            \() ->
+                modelToTypes { name = "empty", attributes = [], comment = "" }
+                    |> Expect.equal []
+        , test "works with parse" <|
+            \() ->
+                let
+                    model =
+                        { name = "test"
+                        , attributes =
+                            [ { name = "id", type_ = Type.Int, default = Nothing, primaryKey = True, null = False, array = False, comment = "" }
+                            ]
+                        , comment = ""
+                        }
+                in
+                Parser.parse (modelToTypes model) "where%5Bid%5D%5Beq%5D=42"
+                    |> Expect.equal (Ok { emptyQuery | predicate = Just (Eq [ "id" ] (StandardApi.Int 42)) })
+        ]
+
+
+dictTests : Test
+dictTests =
+    describe "dict values"
+        [ test "single key dict" <|
+            \() ->
+                -- where[metadata][eq][key]=value -> Eq ["metadata"] (Dict {"key": String "value"})
+                Parser.parse noTypes "where%5Bmetadata%5D%5Beq%5D%5Bkey%5D=value"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | predicate =
+                                    Just (Eq [ "metadata" ] (Dict (Dict.singleton "key" (StandardApi.String "value"))))
+                            }
+                        )
+        , test "multi key dict" <|
+            \() ->
+                -- where[metadata][eq][k1]=v1&where[metadata][eq][k2]=v2
+                Parser.parse noTypes "where%5B%5D%5Bmetadata%5D%5Beq%5D%5Bk1%5D=v1&where%5B%5D%5Bmetadata%5D%5Beq%5D%5Bk2%5D=v2"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | predicate =
+                                    Just
+                                        (Eq [ "metadata" ]
+                                            (Dict
+                                                (Dict.fromList
+                                                    [ ( "k1", StandardApi.String "v1" )
+                                                    , ( "k2", StandardApi.String "v2" )
+                                                    ]
+                                                )
+                                            )
+                                        )
+                            }
+                        )
+        , test "dict roundtrip single key" <|
+            \() ->
+                roundtrip
+                    { emptyQuery
+                        | predicate =
+                            Just (Eq [ "metadata" ] (Dict (Dict.singleton "key" (StandardApi.String "value"))))
+                    }
+        , test "dict roundtrip multi key" <|
+            \() ->
+                roundtrip
+                    { emptyQuery
+                        | predicate =
+                            Just
+                                (Eq [ "metadata" ]
+                                    (Dict
+                                        (Dict.fromList
+                                            [ ( "k1", StandardApi.String "v1" )
+                                            , ( "k2", StandardApi.String "v2" )
+                                            ]
+                                        )
+                                    )
+                                )
+                    }
+        , test "dict with int value" <|
+            \() ->
+                Parser.parse noTypes "where%5Bmetadata%5D%5Beq%5D%5Bcount%5D=42"
+                    |> Expect.equal
+                        (Ok
+                            { emptyQuery
+                                | predicate =
+                                    Just (Eq [ "metadata" ] (Dict (Dict.singleton "count" (StandardApi.Int 42))))
+                            }
+                        )
+        ]

--- a/tests/Url/ParserQueryTest.elm
+++ b/tests/Url/ParserQueryTest.elm
@@ -94,6 +94,10 @@ orderTests =
             \() ->
                 Parser.parse noTypes "order%5Bid%5D=asc&order%5Bname%5D=desc"
                     |> Expect.equal (Ok { emptyQuery | order = [ ( "id", Asc ), ( "name", Desc ) ] })
+        , test "nested order column" <|
+            \() ->
+                Parser.parse noTypes "order%5Bsource_transaction%5D%5Bexecuted_at%5D=desc"
+                    |> Expect.equal (Ok { emptyQuery | order = [ ( "source_transaction.executed_at", Desc ) ] })
         ]
 
 


### PR DESCRIPTION
## Summary
- Add `StandardApi.Url.Parser.Query` module for parsing URL query strings back into `Query` values
- Add `StandardApi.Type` module exposing type information for schema fields
- Add `modelToTypes` helper to convert `Model` to type mappings for parsing
- Implement `parse` and `parseUrl` functions with strict type-driven decoding
- Support parsing of all StandardAPI query parameter conventions (limit, offset, order, predicates, includes)
- Handle Dict values, multi-value operations (In, NotIn, Overlaps), and nested includes
- Update README with comprehensive parser documentation and examples

## Test Coverage
Tests: 193 → 239 (+46 new)
- All new code paths have test coverage
- 239 tests passing, 0 failing
- Coverage includes edge cases, error handling, and roundtrip verification (builder → parser)

## Pre-Landing Review
No issues found.

## Version & CHANGELOG
- Version bumped to 8.0.0 (breaking change to `request`/`requestTask` from prior commits)
- CHANGELOG updated with parser addition and prior fixes

## Documentation
- README.md: Added "URL Parser" section with examples and documentation
- CHANGELOG.md: Added URL Parser, Type module, and modelToTypes function to "Added" section

## Test plan
- [x] All Elm tests pass (239/239)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
